### PR TITLE
Fix image input removal when clearing URL

### DIFF
--- a/components/custom/Settings.jsx
+++ b/components/custom/Settings.jsx
@@ -152,7 +152,7 @@ export default function Settings() {
     return (
         <div className={"p-5 flex flex-col gap-5"}>
             <h2 className={"font-bold text-xl"}>Settings</h2>
-            {element?.imageUrl && (
+            {element?.imageUrl !== undefined && (
                 <ImagePreview
                     label={"Image Preview"}
                     value={element?.imageUrl}


### PR DESCRIPTION
## Summary
- ensure `ImagePreview` input remains visible even if image URL is empty

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_687a2b42cf60832d853004c46cf3c0a1