### PR TITLE
Fix missing toast import and template empty check

### DIFF
--- a/components/custom/Canvas.jsx
+++ b/components/custom/Canvas.jsx
@@ -5,13 +5,12 @@ import {
     useEmailTemplate, useHtmlCode,
     useScreenSize,
 } from "@/app/provider";
-import layout from "@/Data/Layout";
 import { ColumnLayout } from "@/components/LayoutElements/ColumnLayout";
-import Layout from "@/Data/Layout";
 import { ViewHtmlDialog } from "@/components/custom/ViewHtmlDialog";
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {faBan, faFaceSadTear} from "@fortawesome/free-solid-svg-icons";
+import {faBan} from "@fortawesome/free-solid-svg-icons";
+import { toast } from "sonner";
 export function Canvas({ viewHtmlCode, closeDialog }) {
     const htmlref = useRef();
     const { ScreenSize, setScreenSize } = useScreenSize();
@@ -61,9 +60,7 @@ export function Canvas({ viewHtmlCode, closeDialog }) {
     //     console.log("type of email template in canvas",typeof(emailTemplate), emailTemplate);
     // }, [emailTemplate]);
 
-    const [TempTemplate, setTempTemplate] = useState([]);
 
-    const p = [{4:4}, {4:4}, {4:4}, {4:4}];
 
 
     return (
@@ -79,7 +76,7 @@ export function Canvas({ viewHtmlCode, closeDialog }) {
                     ref={htmlref}
                 >
                     {
-                        emailTemplate.length >= 0 ? (
+                        emailTemplate.length > 0 ? (
                             <>
                                 {emailTemplate.map((layout, index) => (
                                     <div key={index}>{getLayoutComponent(layout) || "Empty Component"}</div>

--- a/components/custom/EditorHeader.jsx
+++ b/components/custom/EditorHeader.jsx
@@ -12,6 +12,7 @@ import {api} from "@/convex/_generated/api";
 import {useParams} from "next/navigation";
 import {EmailTemplateContext} from "@/context/EmailTemplateContext";
 import SendEmail from "@/components/custom/SendEmail";
+import { toast } from "sonner";
 
 export const EditorHeader = ({ viewHtmlCode }) => {
     const { ScreenSize, setScreenSize } = useScreenSize();


### PR DESCRIPTION
## Summary
- fix conditional check for empty templates in Canvas
- import `toast` in EditorHeader and Canvas
- remove unused imports and variables

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a1fc1e404832dac0d6ae43e5c5ad7