### PR TITLE
Improve editor settings

### DIFF
--- a/components/Element/ButtonComponent.jsx
+++ b/components/Element/ButtonComponent.jsx
@@ -2,10 +2,18 @@ import React from "react";
 import { Button } from "@/components/ui/button";
 
 export function ButtonComponent({ style, content, url, outerStyle }) {
+    const computedStyle = {
+        ...style,
+        backgroundImage: style?.backgroundImageUrl
+            ? `url(${style.backgroundImageUrl})`
+            : undefined,
+        backgroundColor:
+            style?.backgroundImageUrl ? undefined : style?.backgroundColor || "#ffffff",
+    };
     return (
         <div>
             <a href={url} style={outerStyle}>
-                <Button style={style} className={""}>
+                <Button style={computedStyle} className={""}>
                     {content}
                 </Button>
             </a>

--- a/components/Element/DividerComponent.jsx
+++ b/components/Element/DividerComponent.jsx
@@ -1,9 +1,15 @@
 import React from "react";
 
 export function DividerComponent({ style }) {
+    const computedStyle = {
+        ...style,
+        backgroundImage: style?.backgroundImageUrl
+            ? `url(${style.backgroundImageUrl})`
+            : undefined,
+        backgroundColor:
+            style?.backgroundImageUrl ? undefined : style?.backgroundColor || "#ffffff",
+    };
     return (
-        // <div>
-        <hr style={style} />
-        // </div>
+        <hr style={computedStyle} />
     );
 }

--- a/components/Element/ImageComponent.jsx
+++ b/components/Element/ImageComponent.jsx
@@ -1,16 +1,18 @@
 import React from "react";
-import Image from "next/image";
-
 export function ImageComponent({ style, imageUrl, alt, outerStyle }) {
+    const computedStyle = {
+        ...style,
+        backgroundImage: style?.backgroundImageUrl
+            ? `url(${style.backgroundImageUrl})`
+            : undefined,
+        backgroundColor:
+            style?.backgroundImageUrl ? undefined : style?.backgroundColor || "#ffffff",
+    };
+    const width = parseInt(style?.width) || 150;
+    const height = parseInt(style?.height) || 150;
     return (
-        <div>
-            <Image
-                src={imageUrl}
-                style={style}
-                alt={"Image"}
-                width={150} // Explicit width
-                height={150} // Explicit height
-            />
+        <div style={outerStyle}>
+            <img src={imageUrl} style={computedStyle} alt={alt || "Image"} width={width} height={height} />
         </div>
     );
 }

--- a/components/Element/LogoComponent.jsx
+++ b/components/Element/LogoComponent.jsx
@@ -1,9 +1,19 @@
 import React from "react";
 
 export function LogoComponent({ style, imageUrl, outerStyle }) {
+    const computedStyle = {
+        ...style,
+        backgroundImage: style?.backgroundImageUrl
+            ? `url(${style.backgroundImageUrl})`
+            : undefined,
+        backgroundColor:
+            style?.backgroundImageUrl ? undefined : style?.backgroundColor || "#ffffff",
+    };
+    const width = parseInt(style?.width) || undefined;
+    const height = parseInt(style?.height) || undefined;
     return (
-        <div>
-            <img src={imageUrl} alt={"Logo"} style={style} />
+        <div style={outerStyle}>
+            <img src={imageUrl} alt={"Logo"} style={computedStyle} width={width} height={height} />
         </div>
     );
 }

--- a/components/Element/LogoHeaderComponent.jsx
+++ b/components/Element/LogoHeaderComponent.jsx
@@ -1,9 +1,19 @@
 import React from "react";
 
 export function LogoHeaderComponent({ style, imageUrl, outerStyle }) {
+    const computedStyle = {
+        ...style,
+        backgroundImage: style?.backgroundImageUrl
+            ? `url(${style.backgroundImageUrl})`
+            : undefined,
+        backgroundColor:
+            style?.backgroundImageUrl ? undefined : style?.backgroundColor || "#ffffff",
+    };
+    const width = parseInt(style?.width) || undefined;
+    const height = parseInt(style?.height) || undefined;
     return (
-        <div>
-            <img src={imageUrl} alt={"LogoHeader"} style={style} />
+        <div style={outerStyle}>
+            <img src={imageUrl} alt={"LogoHeader"} style={computedStyle} width={width} height={height} />
         </div>
     );
 }

--- a/components/Element/SocialIconsComponent.jsx
+++ b/components/Element/SocialIconsComponent.jsx
@@ -1,11 +1,24 @@
 import React from "react";
 
 export function SocialIconsComponent({ socialIcons = [], style, outerStyle }) {
+    const computedStyle = {
+        ...style,
+        backgroundImage: style?.backgroundImageUrl
+            ? `url(${style.backgroundImageUrl})`
+            : undefined,
+        backgroundColor:
+            style?.backgroundImageUrl ? undefined : style?.backgroundColor || "#ffffff",
+    };
     return (
         <div style={outerStyle} className="flex gap-2">
             {socialIcons?.map((item, index) => (
-                <a key={index} href={item.url || "#"}>
-                    <img src={item.icon} alt="icon" style={style} />
+                <a
+                    key={index}
+                    href={item.url || "#"}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    <img src={item.icon} alt="icon" style={computedStyle} />
                 </a>
             ))}
         </div>

--- a/components/Element/TextComponent.jsx
+++ b/components/Element/TextComponent.jsx
@@ -1,9 +1,17 @@
 import React from "react";
 
 export function TextComponent({ textarea, style, content, outerStyle }) {
+    const computedStyle = {
+        ...style,
+        backgroundImage: style?.backgroundImageUrl
+            ? `url(${style.backgroundImageUrl})`
+            : undefined,
+        backgroundColor:
+            style?.backgroundImageUrl ? undefined : style?.backgroundColor || "#ffffff",
+    };
     return (
         <div style={outerStyle} className={"w-full"}>
-            <h2 style={style}>{textarea}</h2>
+            <h2 style={computedStyle}>{textarea}</h2>
         </div>
     );
 }

--- a/components/custom/Settings.jsx
+++ b/components/custom/Settings.jsx
@@ -119,6 +119,16 @@ export default function Settings() {
         setSelectedElement(updatedElement);
     };
 
+    const onHandleSocialIconLinkChange = (index, value) => {
+        const updated = { ...SelectedElement };
+        const icons = [...(updated.layout[SelectedElement.index].socialIcons || [])];
+        if (icons[index]) {
+            icons[index] = { ...icons[index], url: value };
+        }
+        updated.layout[SelectedElement.index].socialIcons = icons;
+        setSelectedElement(updated);
+    };
+
     const TextAlignOptions = [
         {
             value: "left",
@@ -203,6 +213,17 @@ export default function Settings() {
                     }
                 />
             )}
+            {element?.style && (
+                <InputField
+                    label={"Background Image URL"}
+                    value={element?.style?.backgroundImageUrl || ""}
+                    onHandleInputChange={(value) =>
+                        onHandleStyleChange("backgroundImageUrl", value)
+                    }
+                    outerStyle={element?.outerStyle}
+                    style={element?.style}
+                />
+            )}
             {element?.url && (
                 <InputField
                     label={"url"}
@@ -211,6 +232,22 @@ export default function Settings() {
                     outerStyle={element?.outerStyle}
                     style={element?.style}
                 />
+            )}
+            {element?.socialIcons && (
+                <div className="flex flex-col gap-2">
+                    {element.socialIcons.map((icon, idx) => (
+                        <InputField
+                            key={idx}
+                            label={`Link ${idx + 1}`}
+                            value={icon.url}
+                            onHandleInputChange={(value) =>
+                                onHandleSocialIconLinkChange(idx, value)
+                            }
+                            outerStyle={element?.outerStyle}
+                            style={element?.style}
+                        />
+                    ))}
+                </div>
             )}
             {
                 <div className={'flex gap-6 bg-gray-100 justify-around'}>
@@ -293,6 +330,15 @@ export default function Settings() {
                     MIN={5}
                     MAX={600}
                     STEP={1}
+                    outerStyle={element?.outerStyle}
+                    style={element?.style}
+                />
+            )}
+            {element?.style?.height && (
+                <InputStyleField
+                    label={"Height"}
+                    value={element?.style?.height}
+                    onHandleStyleChange={(value) => onHandleStyleChange("height", value)}
                     outerStyle={element?.outerStyle}
                     style={element?.style}
                 />


### PR DESCRIPTION
## Summary
- support background image URL and height settings
- handle social icon links
- render background images in all element components

## Testing
- `npm run build` *(fails: NextFontError and missing 'sonner')*

------
https://chatgpt.com/codex/tasks/task_e_687a2f7d0b30832da8efbe27aa241117