### PR TITLE
Add dark mode toggle and toast notifications

### DIFF
--- a/app/(main)/editor/[templateId]/page.jsx
+++ b/app/(main)/editor/[templateId]/page.jsx
@@ -5,6 +5,7 @@ import { Canvas } from "@/components/custom/Canvas";
 import ElementsSideBar from "@/components/custom/ElementsSideBar";
 import Settings from "@/components/custom/Settings";
 import {useEmailTemplate, useScreenSize, useUserDetail} from "@/app/provider";
+import { toast } from "sonner";
 import {useParams} from "next/navigation";
 import {useConvex, useQuery} from "convex/react";
 import {GetTemplateDesign } from "@/convex/emailTemplate";
@@ -44,6 +45,7 @@ function editor() {
             });
             console.log(result, "GetTemplateData");
             setEmailTemplate(result?.design);
+            toast.success("Template loaded");
             console.log(emailTemplate);
             setLoading(false);
         } catch (error) {

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,6 +1,7 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Provider from "@/app/provider";
+import { Toaster } from "sonner";
 
 const geistSans = Geist({
     variable: "--font-geist-sans",
@@ -25,6 +26,7 @@ export default function RootLayout({ children }) {
         >
         <Provider>
             {children}
+            <Toaster position="top-right" richColors />
         </Provider>
         </body>
         </html>

--- a/app/provider.js
+++ b/app/provider.js
@@ -8,6 +8,7 @@ import { EmailTemplateContext } from "@/context/EmailTemplateContext";
 import { SelectedElementContext } from "@/context/SelectedElement";
 import {UserDetailContext} from "@/context/UserDetailContext"
 import {HtmlCodeContext} from "@/context/HtmlCodeContext";
+import {ThemeContext} from "@/context/ThemeContext";
 function Provider({ children }) {
     const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL);
     const [userDetail, setUserDetail] = useState(null);
@@ -16,6 +17,7 @@ function Provider({ children }) {
     const [SelectedElement, setSelectedElement] = useState();
     const [emailTemplate, setEmailTemplate] = useState([]);
     const [htmlCode, setHtmlCode] = useState("");
+    const [theme, setTheme] = useState("light");
 
     useEffect(() => {
         if (typeof window !== "undefined") {
@@ -57,6 +59,12 @@ function Provider({ children }) {
             } else {
                 setEmailTemplate([]); // Fallback to an empty array
             }
+
+            // theme
+            const storedTheme = localStorage.getItem("theme");
+            if (storedTheme === "dark" || storedTheme === "light") {
+                setTheme(storedTheme);
+            }
         }
     }, []);
 
@@ -66,10 +74,22 @@ function Provider({ children }) {
         }
     }, [emailTemplate]);
 
+    useEffect(() => {
+        if (typeof window !== "undefined") {
+            if (theme === "dark") {
+                document.documentElement.classList.add("dark");
+            } else {
+                document.documentElement.classList.remove("dark");
+            }
+            localStorage.setItem("theme", theme);
+        }
+    }, [theme]);
+
     return (
         <ConvexProvider client={convex}>
             <GoogleOAuthProvider clientId={process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}>
                     <UserDetailContext.Provider value={{ userDetail, setUserDetail }}>
+                        <ThemeContext.Provider value={{ theme, setTheme }}>
                         <ScreenSizeContext.Provider value={{ ScreenSize, setScreenSize }}>
                             <DragDropLayoutContext.Provider
                                 value={{ DragElementLayout, setDragElementLayout }}
@@ -88,6 +108,7 @@ function Provider({ children }) {
                                 </EmailTemplateContext.Provider>
                             </DragDropLayoutContext.Provider>
                         </ScreenSizeContext.Provider>
+                        </ThemeContext.Provider>
                     </UserDetailContext.Provider>
                 </GoogleOAuthProvider>
             </ConvexProvider>
@@ -113,4 +134,7 @@ export const useSelectedElement = () => {
 };
 export const useHtmlCode = () => {
     return useContext(HtmlCodeContext);
+};
+export const useTheme = () => {
+    return useContext(ThemeContext);
 };

--- a/components/custom/AIinputBox.jsx
+++ b/components/custom/AIinputBox.jsx
@@ -9,6 +9,7 @@ import {api} from "@/convex/_generated/api";
 import {v4 as uuidv4} from "uuid";
 import {useEmailTemplate, useUserDetail} from "@/app/provider";
 import {LoaderCircle} from "lucide-react";
+import { toast } from "sonner";
 import {useRouter} from "next/navigation";
 import {SaveTemplate} from "@/convex/emailTemplate";
 
@@ -59,6 +60,7 @@ export function AIinputBox() {
             // setEmailTemplate(JSON.parse(result.data?.response));
             // await router.push('/editor/'+tid);
             console.log("Saved Template ID:", respo);
+            toast.success("Template generated successfully!");
             router.push('/editor/' + tid);
 
 
@@ -69,6 +71,7 @@ export function AIinputBox() {
                 || "Failed to generate or save template";
 
             console.error("Error Details:", errorMessage);
+            toast.error(errorMessage);
             setGeneratedTemplate({ error: errorMessage });
         } finally {
             setLoading(false);

--- a/components/custom/EditorHeader.jsx
+++ b/components/custom/EditorHeader.jsx
@@ -2,8 +2,8 @@
 import React, {useContext, useEffect, useState} from "react";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
-import { CodeSquare, Code, Monitor, Smartphone } from "lucide-react";
-import {useEmailTemplate, useScreenSize} from "@/app/provider";
+import { CodeSquare, Code, Monitor, Smartphone, Sun, Moon } from "lucide-react";
+import {useEmailTemplate, useScreenSize, useTheme} from "@/app/provider";
 import Link from "next/link";
 import {useMutation} from "convex/react";
 import {UpdateTemplateDesign} from "@/convex/emailTemplate";
@@ -17,6 +17,7 @@ export const EditorHeader = ({ viewHtmlCode }) => {
     const { ScreenSize, setScreenSize } = useScreenSize();
     const {templateId} = useParams();
     const {emailTemplate, setEmailTemplate} = useEmailTemplate();
+    const { theme, setTheme } = useTheme();
     const UpdateTemplate = useMutation(api.emailTemplate.UpdateTemplateDesign);
 
 
@@ -25,6 +26,7 @@ export const EditorHeader = ({ viewHtmlCode }) => {
             tid: templateId,
             design: emailTemplate,
         });
+        toast.success("Template saved");
     };
 
 
@@ -70,6 +72,16 @@ export const EditorHeader = ({ viewHtmlCode }) => {
             </div>
 
             <div className={"flex gap-3"}>
+                <Button
+                    variant="ghost"
+                    onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+                >
+                    {theme === "dark" ? (
+                        <Sun className="h-5 w-5" />
+                    ) : (
+                        <Moon className="h-5 w-5" />
+                    )}
+                </Button>
                 <Button
                     variant={"ghost"}
                     className={"hover:text-primary    hover:bg-purple-100  "}

--- a/components/custom/Header.jsx
+++ b/components/custom/Header.jsx
@@ -4,11 +4,13 @@ import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { SignInButton } from "@/components/custom/SignInButton";
 // import { useUserDetail } from "@/provider";
-import { useUserDetail } from "@/app/provider";
+import { useUserDetail, useTheme } from "@/app/provider";
+import { Sun, Moon } from "lucide-react";
 import Link from "next/link";
 
 export const Header = () => {
     const { userDetail } = useUserDetail();
+    const { theme, setTheme } = useTheme();
 
     console.log("User Email:", userDetail?.email); // Debugging user email
 
@@ -27,7 +29,13 @@ export const Header = () => {
                     </div>
                 </div>
             </Link>
-            <div>
+            <div className="flex items-center gap-3">
+                <Button
+                    variant="ghost"
+                    onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+                >
+                    {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+                </Button>
                 {
                     userDetail?.email ? (
                     <div className="flex gap-3 items-center">

--- a/components/custom/SendEmail.jsx
+++ b/components/custom/SendEmail.jsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {useHtmlCode} from "@/app/provider";
+import { toast } from "sonner";
 
 export default function SendEmail() {
     const [emails, setEmails] = useState("");
@@ -31,9 +32,15 @@ export default function SendEmail() {
             });
 
             const data = await res.json();
+            if (data.success) {
+                toast.success("Email sent successfully!");
+            } else {
+                toast.error(`Error: ${data.error}`);
+            }
             setResponse(data.success ? "Email sent successfully!" : `Error: ${data.error}`);
         } catch (error) {
             setResponse("Failed to send email");
+            toast.error("Failed to send email");
         }
 
         setLoading(false);

--- a/components/custom/ViewHtmlDialog.jsx
+++ b/components/custom/ViewHtmlDialog.jsx
@@ -8,6 +8,7 @@ import {
     DialogTrigger,
 } from "@/components/ui/dialog";
 import { Copy, Check } from "lucide-react";
+import { toast } from "sonner";
 export function ViewHtmlDialog({ openDialog, htmlCode, closeDialog}) {
     const [isCopied, setIsCopied] = useState(false);
 
@@ -16,6 +17,7 @@ export function ViewHtmlDialog({ openDialog, htmlCode, closeDialog}) {
             .writeText(htmlCode)
             .then(() => {
                 setIsCopied(true);
+                toast.success("HTML copied");
                 setTimeout(() => setIsCopied(false), 1200); // Reset after 2 seconds
             })
             .catch((err) => {

--- a/context/ThemeContext.jsx
+++ b/context/ThemeContext.jsx
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const ThemeContext = createContext(null);


### PR DESCRIPTION
## Summary
- implement global theme context for dark mode
- add dark mode toggle buttons in navigation bars
- display toast notifications for generating, saving, sending and copying templates
- show notification when templates load from the API
- include Toaster component at app root

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687a338546e8832dbab4d59fe1852c1f