### PR TITLE
Implement start-from-scratch workflow

### DIFF
--- a/app/(main)/dashboard/create/page.jsx
+++ b/app/(main)/dashboard/create/page.jsx
@@ -1,9 +1,39 @@
-import React from "react";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+"use client";
+import React, {useState} from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {Sparkles} from "lucide-react";
 import {AIinputBox} from "@/components/custom/AIinputBox";
+import {Button} from "@/components/ui/button";
+import {useMutation} from "convex/react";
+import {api} from "@/convex/_generated/api";
+import {v4 as uuidv4} from "uuid";
+import {useRouter} from "next/navigation";
+import {useUserDetail, useEmailTemplate} from "@/app/provider";
 
 export default function Create() {
+    const [scratchClicked, setScratchClicked] = useState(false);
+    const router = useRouter();
+    const saveTemplate = useMutation(api.emailTemplate.SaveTemplate);
+    const {userDetail} = useUserDetail();
+    const {setEmailTemplate} = useEmailTemplate();
+
+    const handleStartNow = async () => {
+        if(!userDetail?.email) return;
+        const tid = uuidv4();
+        try {
+            await saveTemplate({
+                tid: tid,
+                design: [],
+                email: userDetail.email,
+                description: "Blank Template",
+            });
+            setEmailTemplate([]);
+            router.push('/editor/' + tid);
+        } catch (e) {
+            console.error('Error creating template from scratch', e);
+        }
+    };
+
     return (
         <div className={'px-10 md:px-28 lg:px-64 xl:px-72 mt-20 '}>
             <div className={'flex flex-col items-center '}>
@@ -14,7 +44,13 @@ export default function Create() {
                     design with help of AI
                 </p>
 
-                <Tabs defaultValue="AI" className="w-[500px]  mt-10   ">
+                <Tabs
+                    defaultValue="AI"
+                    className="w-[500px]  mt-10   "
+                    onValueChange={(val) => {
+                        if (val === "Scratch") setScratchClicked(true);
+                    }}
+                >
                     <TabsList>
                         <TabsTrigger value="AI">Create with AI  <Sparkles className={'h-5 w-4 ml-2'}/> </TabsTrigger>
                         <TabsTrigger value="Scratch">Start from Scratch</TabsTrigger>
@@ -24,18 +60,11 @@ export default function Create() {
                     </TabsContent>
                     <TabsContent value="Scratch">
                         <div className={' ml-16 mt-10'}>
-                            {/*
-
-                                todo manually
-
-                                keep a button for start now
-                                create a new id in a table
-                                forward to the editor directly
-                                from here
-                                route + tid
-
-                            */}
-                            Coming soon
+                            {scratchClicked ? (
+                                <Button onClick={handleStartNow}>Start Now</Button>
+                            ) : (
+                                "Coming soon"
+                            )}
                         </div>
                     </TabsContent>
                 </Tabs>


### PR DESCRIPTION
## Summary
- convert create page to a client component
- show **Start Now** button when selecting *Start from Scratch*
- create a blank template via Convex and redirect to the editor

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: network access blocked for fonts and missing module `sonner`)*

------
https://chatgpt.com/codex/tasks/task_e_687a350d301c832d83dee54c7641f947