### PR TITLE
Fix editor lazy load error

### DIFF
--- a/components/custom/Canvas.jsx
+++ b/components/custom/Canvas.jsx
@@ -105,3 +105,5 @@ export const Canvas = React.memo(function Canvas({ viewHtmlCode, closeDialog }) 
         </>
     );
 });
+
+export default Canvas;

--- a/components/custom/EditorHeader.jsx
+++ b/components/custom/EditorHeader.jsx
@@ -102,3 +102,5 @@ export const EditorHeader = ({ viewHtmlCode }) => {
         </div>
     );
 };
+
+export default EditorHeader;


### PR DESCRIPTION
## Summary
- export `EditorHeader` and `Canvas` as default modules

## Testing
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc623d130832db850f5c89b256efa